### PR TITLE
Fix header include

### DIFF
--- a/libfragmentzip/libfragmentzip.c
+++ b/libfragmentzip/libfragmentzip.c
@@ -7,7 +7,7 @@
 //
 
 #include "all_libfragmentzip.h"
-#include <libfragmentzip/libfragmentzip.h>
+#include "libfragmentzip.h"
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>


### PR DESCRIPTION
With pointy brackets, building fails if you have an older libfragmentzip installation in $PREFIX.  
This commit fixes that.